### PR TITLE
Added support of tmpfs as root

### DIFF
--- a/buildroot-2015.02/package/berrybootgui2/init
+++ b/buildroot-2015.02/package/berrybootgui2/init
@@ -86,7 +86,7 @@ if [ "$IMAGE" != "" ]; then
 	fi
 
 	echo Mounting image ${IMAGE}...
-	mount -o loop ${IMAGEPATH} /squashfs
+	mount -o loop,ro ${IMAGEPATH} /squashfs
 	cd /squashfs
 
 	if [ -e berryboot-init ]; then
@@ -119,6 +119,8 @@ if [ "$IMAGE" != "" ]; then
 
 			if [ -e "root_on_tmpfs" ]; then
 				echo "Mounting RW data directory on top (with tmpfs, changes are discarded after reboot)"
+				# remouting SD-card read-only and adding tmpfs layer...
+				mount -nfo remount,ro /mnt
 				mkdir /tmpfs
 				mount -t tmpfs none /tmpfs
 				mount -t aufs -o br:/tmpfs:${SHAREDDIR}:/squashfs none /aufs

--- a/buildroot-2015.02/package/berrybootgui2/init
+++ b/buildroot-2015.02/package/berrybootgui2/init
@@ -120,7 +120,7 @@ if [ "$IMAGE" != "" ]; then
 			if [ -e "root_on_tmpfs" ]; then
 				echo "Mounting RW data directory on top (with tmpfs, changes are discarded after reboot)"
 				# remouting SD-card read-only and adding tmpfs layer...
-				mount -nfo remount,ro /mnt
+				mount -o remount,ro /mnt
 				mkdir /tmpfs
 				mount -t tmpfs none /tmpfs
 				mount -t aufs -o br:/tmpfs:${SHAREDDIR}:/squashfs none /aufs

--- a/buildroot-2015.02/package/berrybootgui2/init
+++ b/buildroot-2015.02/package/berrybootgui2/init
@@ -116,8 +116,17 @@ if [ "$IMAGE" != "" ]; then
 	for initfile in sbin/init usr/lib/systemd/systemd lib/systemd/systemd init
 	do
 		if [ -e $initfile ]; then
-			echo Mounting RW data directory on top
-			mount -t aufs -o br:${DATADIR}:${SHAREDDIR}:/squashfs none /aufs
+
+			if [ -e "root_on_tmpfs" ]; then
+				echo "Mounting RW data directory on top (with tmpfs, changes are discarded after reboot)"
+				mkdir /tmpfs
+				mount -t tmpfs none /tmpfs
+				mount -t aufs -o br:/tmpfs:${SHAREDDIR}:/squashfs none /aufs
+			else
+				echo Mounting RW data directory on top
+				mount -t aufs -o br:${DATADIR}:${SHAREDDIR}:/squashfs none /aufs
+			fi
+
 			cd /aufs
 			mount -o move /dev dev
 			mount -o move /sys sys


### PR DESCRIPTION
Normally the file changes are written to the SD-card. If a file
„root_on_tmpfs“ exist is in the root of the squashfs image then the
changes are stored to a tmpfs (RAM) device. After a reboot all changes
are discarded. Therefore the SD-card is only used by reading and
extends there lifetime.
