### PR TITLE
Allow berryboot-init to reside in /mnt/data

### DIFF
--- a/buildroot-2015.02/package/berrybootgui2/init
+++ b/buildroot-2015.02/package/berrybootgui2/init
@@ -99,6 +99,12 @@ if [ "$IMAGE" != "" ]; then
 		echo Executing init script
 		. berryboot-init
 	fi
+	
+	if [ -e /mnt/data/berryboot-init ]; then
+		echo Executing init script
+		. /mnt/data/berryboot-init $IMAGE
+	fi
+
 
 	#
 	# Fedora and Arch symlink /lib to /usr/lib and expect modules in /usr/lib/modules


### PR DESCRIPTION
as suggested [here](https://github.com/maxnet/berryboot/issues/408#issuecomment-307553361).
This allows users to make & edit custom `berryboot-init` init scripts for particular images, without forcing these to reside within the image itself (which forces cumbersome squashfs image manipulations).
It uses $IMAGE image name as an input so that one single `mnt/data/berryboot-init` script can deal with any image-specific initialization needs.
Also kept initial `berryboot-init` for backward-compatibility reason.

@maxnet of course we could also choose another name for that file...