### PR TITLE
Allow users to make custom images update scripts

### DIFF
--- a/buildroot-2015.02/package/berrybootgui2/init
+++ b/buildroot-2015.02/package/berrybootgui2/init
@@ -90,6 +90,11 @@ if [ "$IMAGE" != "" ]; then
             mv -f ${DATADIR}/storage/.update/SYSTEM ${IMAGEPATH}
             rm -rf ${DATADIR}/storage/.update/*
 	fi
+	
+	if [ -s /mnt/data/custom-images-update ]; then
+		echo Executing custom images update script
+		. /mnt/data/custom-images-update ${IMAGE}
+	fi
 
 	echo Mounting image ${IMAGE}...
 	mount -o loop,ro ${IMAGEPATH} /squashfs

--- a/buildroot-2015.02/package/berrybootgui2/init
+++ b/buildroot-2015.02/package/berrybootgui2/init
@@ -91,7 +91,7 @@ if [ "$IMAGE" != "" ]; then
             rm -rf ${DATADIR}/storage/.update/*
 	fi
 	
-	if [ -s /mnt/data/custom-images-update ]; then
+	if [ -x /mnt/data/custom-images-update ]; then
 		echo "Executing custom images update script"
 		. /mnt/data/custom-images-update ${IMAGE}
 	fi

--- a/buildroot-2015.02/package/berrybootgui2/init
+++ b/buildroot-2015.02/package/berrybootgui2/init
@@ -93,7 +93,7 @@ if [ "$IMAGE" != "" ]; then
 	
 	if [ -x /mnt/data/custom-images-update ]; then
 		echo "Executing custom images update script"
-		. /mnt/data/custom-images-update ${IMAGE}
+		. /mnt/data/custom-images-update
 	fi
 
 	echo Mounting image ${IMAGE}...

--- a/buildroot-2015.02/package/berrybootgui2/init
+++ b/buildroot-2015.02/package/berrybootgui2/init
@@ -92,7 +92,7 @@ if [ "$IMAGE" != "" ]; then
 	fi
 	
 	if [ -s /mnt/data/custom-images-update ]; then
-		echo Executing custom images update script
+		echo "Executing custom images update script"
 		. /mnt/data/custom-images-update ${IMAGE}
 	fi
 


### PR DESCRIPTION
Provides extra flexibility for images updates, in addition to already supported OpenELEC updates.

As it is impossible for berryboot project to provide/maintain/support any possible custom images update procedures (RetroPie, LibreELEC, Volumio, ..., any custom one), this change provides users enough flexibility to do so.
Custom update script to be written as `/mnt/data/custom-images-update`.
Image-specific processing may be triggered thanks to input parameter containing Berryboot UI's image name to be mounted after that script is executed.

This should help for many users' issues raised, such as for exemple:
https://github.com/maxnet/berryboot/issues/358#issuecomment-278759437
https://github.com/maxnet/berryboot/issues/343#issuecomment-272138039
https://github.com/maxnet/berryboot/issues/284
Would help resolving https://github.com/maxnet/berryboot/issues/400 (simpler change and maintains existing OpenELEC stuff)
Thanks for consideration.

note: this is different matter than https://github.com/maxnet/berryboot/pull/409