### PR TITLE
inline berryboot-init from / (or "$IMAGEPATH")

### DIFF
--- a/buildroot-2015.02/package/berrybootgui2/init
+++ b/buildroot-2015.02/package/berrybootgui2/init
@@ -97,7 +97,8 @@ if [ "$IMAGE" != "" ]; then
 
 	if [ -e berryboot-init ]; then
 		echo Executing init script
-		. berryboot-init
+		cp berryboot-init /.
+		. /berryboot-init
 	fi
 
 	#


### PR DESCRIPTION
By doing this, it would allow `berryboot-init` to be ran without holding its file in `/squashfs` during execution.
So, things like unmounting a squash image should then be possible, hence allowing `berryboot-init` to perform custom image updates.

@maxnet , would this be more acceptable than PR https://github.com/maxnet/berryboot/pull/410 intended for same custom image updates purpose?
Thanks for consideration & feedback.