### PR TITLE
New Pi foundation brcm firmware repo

### DIFF
--- a/buildroot-2015.02/package/rpi-wifi-firmware/rpi-wifi-firmware.mk
+++ b/buildroot-2015.02/package/rpi-wifi-firmware/rpi-wifi-firmware.mk
@@ -10,9 +10,9 @@ RPI_WIFI_FIRMWARE_LICENSE = Proprietary
 RPI_WIFI_FIRMWARE_LICENSE_FILES = brcm80211/LICENSE
 
 define RPI_WIFI_FIRMWARE_INSTALL_TARGET_CMDS
-	$(INSTALL) -D -m 0644 $(@D)/brcm80211/brcm/brcmfmac43143.bin $(TARGET_DIR)/lib/firmware/brcm/brcmfmac43143.bin
-	$(INSTALL) -D -m 0644 $(@D)/brcm80211/brcm/brcmfmac43430-sdio.bin $(TARGET_DIR)/lib/firmware/brcm/brcmfmac43430-sdio.bin
-	$(INSTALL) -D -m 0644 $(@D)/brcm80211/brcm/brcmfmac43430-sdio.txt $(TARGET_DIR)/lib/firmware/brcm/brcmfmac43430-sdio.txt
+	$(INSTALL) -D -m 0644 $(@D)/brcm/brcmfmac43143.bin $(TARGET_DIR)/lib/firmware/brcm/brcmfmac43143.bin
+	$(INSTALL) -D -m 0644 $(@D)/brcm/brcmfmac43430-sdio.bin $(TARGET_DIR)/lib/firmware/brcm/brcmfmac43430-sdio.bin
+	$(INSTALL) -D -m 0644 $(@D)/brcm/brcmfmac43430-sdio.txt $(TARGET_DIR)/lib/firmware/brcm/brcmfmac43430-sdio.txt
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
brcm firmware has just moved to https://github.com/RPi-Distro/firmware-nonfree/tree/master/brcm
Fixes https://github.com/maxnet/berryboot/issues/467