### PR TITLE
Update disable-bt overlay name

### DIFF
--- a/output/config.txt
+++ b/output/config.txt
@@ -4,7 +4,7 @@ gpu_mem=160
 
 # Uncomment to enable serial console
 #enable_uart=1
-#dtoverlay=pi3-disable-bt
+#dtoverlay=disable-bt
 
 # Enable on-board audio
 dtparam=audio=on


### PR DESCRIPTION
The device tree overlay to disable onboard Bluetooth has been renamed from "pi3-disable-bt" to "disable-bt", which is true as well for the Linux 4.19.y branch that is used for non-pi64 Berryboot builds: https://github.com/raspberrypi/firmware/blob/163d84cbeb7038a4fd71d817eae43a535eb3df62/boot/overlays/README#L1766-L1769

I forgot to add a sign-off to the commit, but can amend it, if preferred.