### PR TITLE
Remove obsolete elevator boot argument

### DIFF
--- a/output/cmdline.txt
+++ b/output/cmdline.txt
@@ -1,1 +1,1 @@
-elevator=deadline quiet bootmenutimeout=10
+quiet bootmenutimeout=10


### PR DESCRIPTION
With the Raspberry Pi kernel v5.10, the elevator argument has no effect anymore and produces a warning at boot: https://github.com/raspberrypi/linux/commit/f8db383507d658c5a729b062c97710efda876cd4

"mq-deadline" is now the default I/O scheduler and it can be adjusted per-drive via sysfs, permanently e.g. via udev rules.